### PR TITLE
Feature to directly push notification without scheduling

### DIFF
--- a/alarmee/src/androidMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerAndroid.kt
+++ b/alarmee/src/androidMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerAndroid.kt
@@ -107,7 +107,7 @@ class AlarmeeSchedulerAndroid(
         }
     }
 
-    override fun pushNotificationNow(alarmee: Alarmee, onSuccess: () -> Unit) {
+    override fun pushAlarmee(alarmee: Alarmee, onSuccess: () -> Unit) {
         createNotificationChannels(context = context)
         validateNotificationChannelId(alarmee)
 

--- a/alarmee/src/androidMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerAndroid.kt
+++ b/alarmee/src/androidMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerAndroid.kt
@@ -107,7 +107,7 @@ class AlarmeeSchedulerAndroid(
         }
     }
 
-    fun pushNotificationNow(uuid: String, title: String, body: String, channelId: String, priority: AndroidNotificationPriority) {
+    override fun pushNotificationNow(uuid: String, title: String, body: String, channelId: String, priority: AndroidNotificationPriority) {
         createNotificationChannels(context = context)
         validateNotificationChannelId(channelId = channelId)
 

--- a/alarmee/src/commonMain/kotlin/com/tweener/alarmee/Alarmee.kt
+++ b/alarmee/src/commonMain/kotlin/com/tweener/alarmee/Alarmee.kt
@@ -27,7 +27,7 @@ data class Alarmee(
     val uuid: String,
     val notificationTitle: String,
     val notificationBody: String,
-    val scheduledDateTime: LocalDateTime,
+    val scheduledDateTime: LocalDateTime? = null,
     val timeZone: TimeZone = TimeZone.currentSystemDefault(),
     val repeatInterval: RepeatInterval? = null,
     val androidNotificationConfiguration: AndroidNotificationConfiguration,

--- a/alarmee/src/commonMain/kotlin/com/tweener/alarmee/Alarmee.kt
+++ b/alarmee/src/commonMain/kotlin/com/tweener/alarmee/Alarmee.kt
@@ -15,7 +15,7 @@ import kotlinx.datetime.TimeZone
  * @property uuid A unique identifier for the alarm.
  * @property notificationTitle The title of the notification that will be displayed when the alarm triggers.
  * @property notificationBody The body of the notification that will be displayed when the alarm triggers.
- * @property scheduledDateTime The specific date and time when the alarm is scheduled to trigger.
+ * @property scheduledDateTime The specific date and time when the alarm is scheduled to trigger. Optional for pushing the notification immediately
  * @property timeZone The time zone in which the alarm should be scheduled. By default, this is set to the system's current time zone.
  * @property repeatInterval The optional interval at which the alarm should repeat (e.g., hourly, daily, weekly). If `null`, the alarm will not repeat.
  * @property androidNotificationConfiguration Configuration specific to Android notifications, including channel ID and priority.

--- a/alarmee/src/commonMain/kotlin/com/tweener/alarmee/AlarmeeScheduler.kt
+++ b/alarmee/src/commonMain/kotlin/com/tweener/alarmee/AlarmeeScheduler.kt
@@ -68,7 +68,7 @@ abstract class AlarmeeScheduler {
     fun push(alarmee: Alarmee) {
         validateAlarmee(alarmee)
 
-        pushNotificationNow(alarmee = alarmee) {
+        pushAlarmee(alarmee = alarmee) {
             println("Notification with title '${alarmee.notificationTitle}' successfully sent.")
         }
     }

--- a/alarmee/src/commonMain/kotlin/com/tweener/alarmee/AlarmeeScheduler.kt
+++ b/alarmee/src/commonMain/kotlin/com/tweener/alarmee/AlarmeeScheduler.kt
@@ -90,7 +90,7 @@ abstract class AlarmeeScheduler {
 
     internal abstract fun cancelAlarm(uuid: String)
 
-    abstract fun pushNotificationNow(alarmee: Alarmee, onSuccess: () -> Unit)
+    internal abstract fun pushAlarmee(alarmee: Alarmee, onSuccess: () -> Unit)
 
     private fun validateAlarmee(alarmee: Alarmee, schedule: Boolean = false) {
 

--- a/alarmee/src/iosMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerIos.kt
+++ b/alarmee/src/iosMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerIos.kt
@@ -25,7 +25,6 @@ import platform.UserNotifications.UNCalendarNotificationTrigger
 import platform.UserNotifications.UNMutableNotificationContent
 import platform.UserNotifications.UNNotificationRequest
 import platform.UserNotifications.UNNotificationTrigger
-import platform.UserNotifications.UNPushNotificationTrigger
 import platform.UserNotifications.UNTimeIntervalNotificationTrigger
 import platform.UserNotifications.UNUserNotificationCenter
 
@@ -114,7 +113,7 @@ class AlarmeeSchedulerIos(
         notificationCenter.removePendingNotificationRequestsWithIdentifiers(identifiers = listOf(uuid, getFirstRepeatingNotificationUuid(uuid = uuid)))
     }
 
-    override fun pushNotificationNow(alarmee: Alarmee, onSuccess: () -> Unit) {
+    override fun pushAlarmee(alarmee: Alarmee, onSuccess: () -> Unit) {
         val trigger = UNTimeIntervalNotificationTrigger.triggerWithTimeInterval(1.0, false)
 
         configureNotification(

--- a/alarmee/src/iosMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerIos.kt
+++ b/alarmee/src/iosMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerIos.kt
@@ -114,7 +114,7 @@ class AlarmeeSchedulerIos(
     }
 
     override fun pushAlarmee(alarmee: Alarmee, onSuccess: () -> Unit) {
-        val trigger = UNTimeIntervalNotificationTrigger.triggerWithTimeInterval(1.0, false)
+        val trigger = null
 
         configureNotification(
             uuid = alarmee.uuid,
@@ -124,7 +124,7 @@ class AlarmeeSchedulerIos(
         )
     }
 
-    private fun configureNotification(uuid: String, alarmee: Alarmee, notificationTrigger: UNNotificationTrigger, onSuccess: () -> Unit) {
+    private fun configureNotification(uuid: String, alarmee: Alarmee, notificationTrigger: UNNotificationTrigger?, onSuccess: () -> Unit) {
         val content = UNMutableNotificationContent().apply {
             setTitle(alarmee.notificationTitle)
             setBody(alarmee.notificationBody)

--- a/alarmee/src/iosMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerIos.kt
+++ b/alarmee/src/iosMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerIos.kt
@@ -113,7 +113,7 @@ class AlarmeeSchedulerIos(
         notificationCenter.removePendingNotificationRequestsWithIdentifiers(identifiers = listOf(uuid, getFirstRepeatingNotificationUuid(uuid = uuid)))
     }
 
-    fun pushNotificationNow(uuid: String, title: String, body: String, channelId: String, priority: AndroidNotificationPriority) {
+    override fun pushNotificationNow(uuid: String, title: String, body: String, channelId: String, priority: AndroidNotificationPriority) {
         val content = UNMutableNotificationContent().apply {
             setTitle(title)
             setBody(body)

--- a/alarmee/src/jsMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerJs.kt
+++ b/alarmee/src/jsMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerJs.kt
@@ -33,7 +33,7 @@ class AlarmeeSchedulerJs(
         TODO("Not yet implemented")
     }
 
-    override fun pushNotificationNow(uuid: String, title: String, body: String, channelId: String, priority: AndroidNotificationPriority) {
+    override fun pushNotificationNow(alarmee: Alarmee, onSuccess: () -> Unit) {
         TODO("Not yet implemented")
     }
 }

--- a/alarmee/src/jsMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerJs.kt
+++ b/alarmee/src/jsMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerJs.kt
@@ -34,20 +34,6 @@ class AlarmeeSchedulerJs(
     }
 
     override fun pushNotificationNow(uuid: String, title: String, body: String, channelId: String, priority: AndroidNotificationPriority) {
-        if (!("Notification" in js("window"))) {
-            println("This browser does not support notifications.")
-            return
-        }
-
-        val permission = js("Notification.permission").toString()
-        if (permission == "granted") {
-            val notification = js("new Notification(title, { body: body })")
-        } else if (permission != "denied") {
-            js("Notification.requestPermission()").then { result ->
-                if (result == "granted") {
-                    val notification = js("new Notification(title, { body: body })")
-                }
-            }
-        }
+        TODO("Not yet implemented")
     }
 }

--- a/alarmee/src/jsMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerJs.kt
+++ b/alarmee/src/jsMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerJs.kt
@@ -33,7 +33,7 @@ class AlarmeeSchedulerJs(
         TODO("Not yet implemented")
     }
 
-    override fun pushNotificationNow(alarmee: Alarmee, onSuccess: () -> Unit) {
+    override fun pushAlarmee(alarmee: Alarmee, onSuccess: () -> Unit) {
         TODO("Not yet implemented")
     }
 }

--- a/alarmee/src/jvmMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerJvm.kt
+++ b/alarmee/src/jvmMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerJvm.kt
@@ -33,7 +33,7 @@ class AlarmeeSchedulerJvm(
         TODO("Not yet implemented")
     }
 
-    override fun pushNotificationNow(alarmee: Alarmee, onSuccess: () -> Unit) {
+    override fun pushAlarmee(alarmee: Alarmee, onSuccess: () -> Unit) {
         TODO("Not yet implemented")
     }
 }

--- a/alarmee/src/jvmMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerJvm.kt
+++ b/alarmee/src/jvmMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerJvm.kt
@@ -35,7 +35,7 @@ class AlarmeeSchedulerJvm(
         TODO("Not yet implemented")
     }
 
-    override fun pushNotificationNow(uuid: String, title: String, body: String, channelId: String, priority: AndroidNotificationPriority) {
+    override fun pushNotificationNow(alarmee: Alarmee, onSuccess: () -> Unit) {
         TODO("Not yet implemented")
     }
 }

--- a/alarmee/src/jvmMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerJvm.kt
+++ b/alarmee/src/jvmMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerJvm.kt
@@ -36,16 +36,6 @@ class AlarmeeSchedulerJvm(
     }
 
     override fun pushNotificationNow(uuid: String, title: String, body: String, channelId: String, priority: AndroidNotificationPriority) {
-        if (SystemTray.isSupported()) {
-            val tray = SystemTray.getSystemTray()
-            val image = Toolkit.getDefaultToolkit().createImage("icon.png")
-            val trayIcon = TrayIcon(image, "Tray Demo")
-            trayIcon.isImageAutoSize = true
-            trayIcon.toolTip = "System tray icon demo"
-            trayIcon.displayMessage(title, body, MessageType.INFO)
-            tray.add(trayIcon)
-        } else {
-            println("System tray not supported!")
-        }
+        TODO("Not yet implemented")
     }
 }

--- a/alarmee/src/jvmMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerJvm.kt
+++ b/alarmee/src/jvmMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerJvm.kt
@@ -4,8 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import com.tweener.alarmee.configuration.AlarmeePlatformConfiguration
 import com.tweener.alarmee.configuration.AlarmeeJvmPlatformConfiguration
-import java.awt.*
-import java.awt.TrayIcon.MessageType
 
 /**
  * @author Vivien Mahe

--- a/alarmee/src/wasmJsMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerWasmJs.kt
+++ b/alarmee/src/wasmJsMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerWasmJs.kt
@@ -33,7 +33,7 @@ class AlarmeeSchedulerWasmJs(
         TODO("Not yet implemented")
     }
 
-    override fun pushNotificationNow(alarmee: Alarmee, onSuccess: () -> Unit) {
+    override fun pushAlarmee(alarmee: Alarmee, onSuccess: () -> Unit) {
         TODO("Not yet implemented")
     }
 }

--- a/alarmee/src/wasmJsMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerWasmJs.kt
+++ b/alarmee/src/wasmJsMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerWasmJs.kt
@@ -33,7 +33,7 @@ class AlarmeeSchedulerWasmJs(
         TODO("Not yet implemented")
     }
 
-    override fun pushNotificationNow(uuid: String, title: String, body: String, channelId: String, priority: AndroidNotificationPriority) {
+    override fun pushNotificationNow(alarmee: Alarmee, onSuccess: () -> Unit) {
         TODO("Not yet implemented")
     }
 }

--- a/alarmee/src/wasmJsMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerWasmJs.kt
+++ b/alarmee/src/wasmJsMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerWasmJs.kt
@@ -34,20 +34,6 @@ class AlarmeeSchedulerWasmJs(
     }
 
     override fun pushNotificationNow(uuid: String, title: String, body: String, channelId: String, priority: AndroidNotificationPriority) {
-        if (!("Notification" in js("window"))) {
-            println("This browser does not support notifications.")
-            return
-        }
-
-        val permission = js("Notification.permission").toString()
-        if (permission == "granted") {
-            val notification = js("new Notification(title, { body: body })")
-        } else if (permission != "denied") {
-            js("Notification.requestPermission()").then { result ->
-                if (result == "granted") {
-                    val notification = js("new Notification(title, { body: body })")
-                }
-            }
-        }
+        TODO("Not yet implemented")
     }
 }

--- a/sample/composeApp/src/androidMain/kotlin/com/tweener/alarmee/sample/Platform.android.kt
+++ b/sample/composeApp/src/androidMain/kotlin/com/tweener/alarmee/sample/Platform.android.kt
@@ -18,5 +18,6 @@ actual fun createAlarmeePlatformConfiguration(): AlarmeePlatformConfiguration =
         notificationChannels = listOf(
             AlarmeeNotificationChannel(id = "dailyNewsChannelId", name = "Daily news notifications"),
             AlarmeeNotificationChannel(id = "breakingNewsChannelId", name = "Breaking news notifications", importance = NotificationManager.IMPORTANCE_HIGH),
+            AlarmeeNotificationChannel(id = "immediateChannelId", name = "Immediate Notification", importance = NotificationManager.IMPORTANCE_HIGH),
         )
     )

--- a/sample/composeApp/src/commonMain/kotlin/com/tweener/alarmee/sample/App.kt
+++ b/sample/composeApp/src/commonMain/kotlin/com/tweener/alarmee/sample/App.kt
@@ -95,12 +95,16 @@ fun App() {
                 }) { Text("Set a custom repeating Alarmee") }
 
                 Button(onClick = {
-                    alarmeeScheduler.pushNotificationNow(
-                        uuid = "immediateNotificationId",
-                        title = "🚀 Immediate Notification",
-                        body = "This is an immediate notification pushed without any schedule.",
-                        channelId = "immediateChannelId",
-                        priority = AndroidNotificationPriority.HIGH
+                    alarmeeScheduler.push(
+                        alarmee = Alarmee(
+                            uuid = "immediateNotificationId",
+                            notificationTitle = "🚀 Immediate Notification",
+                            notificationBody = "This is an immediate notification pushed without any schedule.",
+                            androidNotificationConfiguration = AndroidNotificationConfiguration(
+                                priority = AndroidNotificationPriority.MINIMUM,
+                                channelId = "immediateChannelId"
+                            ),
+                        )
                     )
                 }) { Text("Push Notification Now") }
             }


### PR DESCRIPTION
Sometimes, we need to push notifications immediately without scheduling. Much like what KMPNotifier does. But there's no direct function in Alarmee for that. We could basically schedule a notification after short time (say 1 second) as a workaround. But it is not robust because sometimes it takes a little bit of time to grant the permission and/or some time to actually process the notification request. This sometimes makes the scheduled time in a past date and causes it to automatically schedule it for next day which is not an expected behavior. So I have added a function in AlarmeeScheduler.kt file called `push` which follows the function signature of `schedule` function. Below are some example screenshots from iOS and Android where this `push` feature is implemented in the sample app.

## Android
<img src="https://github.com/user-attachments/assets/0409696b-3e61-422c-8d86-199f63902a6a" width="240">

## iOS
<img src="https://github.com/user-attachments/assets/c84d3a4e-6b74-4707-b898-b8c6d208ba13" width="240">
