### PR TITLE
2.0.1

### DIFF
--- a/alarmee/build.gradle.kts
+++ b/alarmee/build.gradle.kts
@@ -150,7 +150,12 @@ version = ProjectConfiguration.Alarmee.versionName
 
 mavenPublishing {
     publishToMavenCentral(host = SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
-    signAllPublications()
+
+    // Only enable signing if the flag is true
+    if (findProperty("mavenPublishing.signAllPublications")?.toString()?.toBoolean() == true) {
+        signAllPublications()
+    }
+
     coordinates(groupId = group.toString(), artifactId = ProjectConfiguration.Alarmee.Maven.name.lowercase(), version = version.toString())
     configure(
         platform = KotlinMultiplatform(

--- a/alarmee/src/androidMain/kotlin/com/tweener/alarmee/DefaultAlarmeeService.android.kt
+++ b/alarmee/src/androidMain/kotlin/com/tweener/alarmee/DefaultAlarmeeService.android.kt
@@ -8,3 +8,7 @@ package com.tweener.alarmee
 actual fun initializeFirebase() {
     // Nothing to do here
 }
+
+actual fun configureFirebase() {
+    // Nothing to do here
+}

--- a/alarmee/src/androidMain/kotlin/com/tweener/alarmee/DefaultPushNotificationService.android.kt
+++ b/alarmee/src/androidMain/kotlin/com/tweener/alarmee/DefaultPushNotificationService.android.kt
@@ -1,5 +1,8 @@
 package com.tweener.alarmee
 
+import dev.gitlive.firebase.Firebase
+import dev.gitlive.firebase.messaging.messaging
+
 /**
  * @author Vivien Mahe
  * @since 05/06/2025
@@ -8,3 +11,10 @@ package com.tweener.alarmee
 internal actual fun handleNotificationData(data: Map<String, String>) {
     println("Handling notification data on Android: $data")
 }
+
+internal actual suspend fun getFirebaseToken(): String =
+    try {
+        Firebase.messaging.getToken()
+    } catch (throwable: Throwable) {
+        throw throwable
+    }

--- a/alarmee/src/commonMain/kotlin/com/tweener/alarmee/AlarmeeService.kt
+++ b/alarmee/src/commonMain/kotlin/com/tweener/alarmee/AlarmeeService.kt
@@ -9,8 +9,8 @@ fun rememberAlarmeeService(
     platformConfiguration: AlarmeePlatformConfiguration
 ): AlarmeeService =
     remember(platformConfiguration) {
-        createAlarmeeService(platformConfiguration).apply {
-            onAppLaunch(platformConfiguration)
+        createAlarmeeService().apply {
+            initialize(platformConfiguration)
         }
     }
 
@@ -18,7 +18,7 @@ fun rememberAlarmeeService(
  * Entry point of the Alarmee library.
  *
  * This service allows you to schedule, trigger, and cancel alarms using the [LocalNotificationService].
- * It must be initialized when your app starts by calling [onAppLaunch], typically in your root `App()` composable.
+ * It must be initialized when your app starts by calling [initialize], typically in your root `App()` composable.
  *
  * Platform-specific configuration is passed through [AlarmeePlatformConfiguration].
  *
@@ -50,7 +50,10 @@ interface AlarmeeService {
      * ```kotlin
      * val alarmeeService = rememberAlarmeeService(createAlarmeePlatformConfiguration())
      * ```
+     *
+     * Use this method if your app does not already use a Firebase instance.
+     *
+     * @param platformConfiguration The platform-specific configuration for Alarmee.
      */
-    fun onAppLaunch(platformConfiguration: AlarmeePlatformConfiguration)
-
+    fun initialize(platformConfiguration: AlarmeePlatformConfiguration)
 }

--- a/alarmee/src/commonMain/kotlin/com/tweener/alarmee/DefaultAlarmeeService.kt
+++ b/alarmee/src/commonMain/kotlin/com/tweener/alarmee/DefaultAlarmeeService.kt
@@ -13,14 +13,19 @@ internal open class DefaultAlarmeeService : AlarmeeService {
     override lateinit var local: LocalNotificationService
     private var isInitialized = false
 
-    override fun onAppLaunch(platformConfiguration: AlarmeePlatformConfiguration) {
+    override fun initialize(platformConfiguration: AlarmeePlatformConfiguration) {
+        initializeFirebase()
+        init(platformConfiguration = platformConfiguration)
+    }
+
+    protected fun init(platformConfiguration: AlarmeePlatformConfiguration) {
         // Check if the service is already initialized to prevent re-initialization
         if (isInitialized) {
             println("AlarmeeService is already initialized.")
             return
         }
 
-        initializeFirebase()
+        configureFirebase()
 
         config = platformConfiguration
 
@@ -28,11 +33,15 @@ internal open class DefaultAlarmeeService : AlarmeeService {
         local = createLocalNotificationService(config)
 
         isInitialized = true
+
+        println("Alarmee is initialized.")
     }
 }
 
-expect fun createAlarmeeService(config: AlarmeePlatformConfiguration): AlarmeeService
+expect fun createAlarmeeService(): AlarmeeService
 
-expect fun createLocalNotificationService(config: AlarmeePlatformConfiguration): LocalNotificationService
+internal expect fun createLocalNotificationService(config: AlarmeePlatformConfiguration): LocalNotificationService
 
-expect fun initializeFirebase()
+internal expect fun initializeFirebase()
+
+internal expect fun configureFirebase()

--- a/alarmee/src/iosMain/kotlin/com/tweener/alarmee/DefaultAlarmeeService.ios.kt
+++ b/alarmee/src/iosMain/kotlin/com/tweener/alarmee/DefaultAlarmeeService.ios.kt
@@ -22,10 +22,11 @@ import platform.darwin.NSObject
  * @since 05/06/2025
  */
 
-@OptIn(ExperimentalForeignApi::class)
 actual fun initializeFirebase() {
     Firebase.initialize()
+}
 
+actual fun configureFirebase() {
     FIRMessaging.messaging().delegate = FirebaseMessageDelegate()
     UIApplication.sharedApplication.registerForRemoteNotifications()
 }
@@ -33,8 +34,6 @@ actual fun initializeFirebase() {
 private class FirebaseMessageDelegate : FIRMessagingDelegateProtocol, NSObject() {
 
     override fun messaging(messaging: FIRMessaging, didReceiveRegistrationToken: String?) {
-//        println("Firebase registration token received: $didReceiveRegistrationToken")
-//
 //        val hexToken = messaging.APNSToken?.toHexString()
 //        println("APNS current token: $hexToken")
     }

--- a/alarmee/src/iosMain/kotlin/com/tweener/alarmee/DefaultPushNotificationService.ios.kt
+++ b/alarmee/src/iosMain/kotlin/com/tweener/alarmee/DefaultPushNotificationService.ios.kt
@@ -1,5 +1,11 @@
 package com.tweener.alarmee
 
+import cocoapods.FirebaseMessaging.FIRMessaging
+import dev.gitlive.firebase.Firebase
+import dev.gitlive.firebase.messaging.messaging
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.coroutines.delay
+
 /**
  * @author Vivien Mahe
  * @since 05/06/2025
@@ -8,4 +14,22 @@ package com.tweener.alarmee
 internal actual fun handleNotificationData(data: Map<String, String>) {
     // On iOS, we let the system display the notification. But we can still get the data attached to the notification.
     println("Handling notification data on iOS: $data")
+}
+
+@OptIn(ExperimentalForeignApi::class)
+internal actual suspend fun getFirebaseToken(): String {
+    var attempts = 0
+    val maxAttempts = 10
+    val delayMillis = 500L
+
+    while (FIRMessaging.messaging().APNSToken == null && attempts < maxAttempts) {
+        delay(delayMillis)
+        attempts++
+    }
+
+    return try {
+        Firebase.messaging.getToken()
+    } catch (throwable: Throwable) {
+        throw throwable
+    }
 }

--- a/alarmee/src/mobileMain/kotlin/com/tweener/alarmee/DefaultAlarmeeService.mobile.kt
+++ b/alarmee/src/mobileMain/kotlin/com/tweener/alarmee/DefaultAlarmeeService.mobile.kt
@@ -1,13 +1,9 @@
 package com.tweener.alarmee
 
-import com.tweener.alarmee.configuration.AlarmeePlatformConfiguration
-
 /**
  * @author Vivien Mahe
  * @since 05/06/2025
  */
 
-actual fun createAlarmeeService(config: AlarmeePlatformConfiguration): AlarmeeService =
-    MobileDefaultAlarmeeService().apply {
-        onAppLaunch(platformConfiguration = config)
-    }
+actual fun createAlarmeeService(): AlarmeeService =
+    MobileDefaultAlarmeeService()

--- a/alarmee/src/mobileMain/kotlin/com/tweener/alarmee/DefaultPushNotificationService.kt
+++ b/alarmee/src/mobileMain/kotlin/com/tweener/alarmee/DefaultPushNotificationService.kt
@@ -1,6 +1,7 @@
 package com.tweener.alarmee
 
 import com.tweener.alarmee.configuration.AlarmeePlatformConfiguration
+import com.tweener.kmpkit.thread.suspendCatching
 import dev.gitlive.firebase.Firebase
 import dev.gitlive.firebase.messaging.messaging
 import kotlinx.coroutines.CoroutineScope
@@ -19,13 +20,6 @@ internal class DefaultPushNotificationService(
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
-    override fun register() {
-        scope.launch {
-//            val token = Firebase.messaging.getToken()
-//            println("Firebase current token: $token")
-        }
-    }
-
     override fun unregister() {
         scope.launch {
             Firebase.messaging.deleteToken()
@@ -36,6 +30,14 @@ internal class DefaultPushNotificationService(
     override fun onMessageReceived(data: Map<String, String>) {
         handleNotificationData(data)
     }
+
+    override suspend fun getToken(): Result<String> = suspendCatching {
+        getFirebaseToken()
+    }.onFailure { throwable ->
+        println("Error getting Firebase token: $throwable")
+    }
 }
 
 internal expect fun handleNotificationData(data: Map<String, String>)
+
+internal expect suspend fun getFirebaseToken(): String

--- a/alarmee/src/mobileMain/kotlin/com/tweener/alarmee/MobileAlarmeeService.kt
+++ b/alarmee/src/mobileMain/kotlin/com/tweener/alarmee/MobileAlarmeeService.kt
@@ -1,5 +1,8 @@
 package com.tweener.alarmee
 
+import com.tweener.alarmee.configuration.AlarmeePlatformConfiguration
+import dev.gitlive.firebase.Firebase
+
 /**
  * Platform-specific extension of [AlarmeeService] for mobile platforms (Android and iOS).
  *
@@ -26,4 +29,20 @@ interface MobileAlarmeeService : AlarmeeService {
      * Only available on Android and iOS targets.
      */
     val push: PushNotificationService
+
+    /**
+     * Initializes the Alarmee service with platform-specific configuration and Firebase instance.
+     *
+     * This method **must be called once when the app is launched**. For example, in your root Composable:
+     *
+     * ```kotlin
+     * val alarmeeService = rememberAlarmeeService(createAlarmeePlatformConfiguration())
+     * ```
+     *
+     * Use this method if your app already uses a Firebase instance.
+     *
+     * @param platformConfiguration The platform-specific configuration for Alarmee.
+     * @param firebase The Firebase instance used to initialize Firebase Messaging.
+     */
+    fun initialize(platformConfiguration: AlarmeePlatformConfiguration, firebase: Firebase)
 }

--- a/alarmee/src/mobileMain/kotlin/com/tweener/alarmee/MobileDefaultAlarmeeService.kt
+++ b/alarmee/src/mobileMain/kotlin/com/tweener/alarmee/MobileDefaultAlarmeeService.kt
@@ -1,6 +1,7 @@
 package com.tweener.alarmee
 
 import com.tweener.alarmee.configuration.AlarmeePlatformConfiguration
+import dev.gitlive.firebase.Firebase
 
 /**
  * @author Vivien Mahe
@@ -10,11 +11,10 @@ internal class MobileDefaultAlarmeeService : DefaultAlarmeeService(), MobileAlar
 
     override lateinit var push: PushNotificationService
 
-    override fun onAppLaunch(platformConfiguration: AlarmeePlatformConfiguration) {
-        super.onAppLaunch(platformConfiguration)
+    override fun initialize(platformConfiguration: AlarmeePlatformConfiguration, firebase: Firebase) {
+        init(platformConfiguration = platformConfiguration)
 
         push = DefaultPushNotificationService(platformConfiguration)
         PushNotificationServiceRegistry.register(push)
     }
 }
-

--- a/alarmee/src/mobileMain/kotlin/com/tweener/alarmee/PushNotificationService.kt
+++ b/alarmee/src/mobileMain/kotlin/com/tweener/alarmee/PushNotificationService.kt
@@ -13,25 +13,26 @@ package com.tweener.alarmee
 interface PushNotificationService {
 
     /**
-     * Registers the device for receiving push notifications.
-     * On Android, this may retrieve the Firebase Cloud Messaging (FCM) token.
-     * On iOS, this requests permission and registers for remote notifications.
-     */
-    fun register()
-
-    /**
      * Unregisters the device from receiving push notifications.
      * Typically used when the user signs out or disables notifications.
      */
     fun unregister()
 
     /**
-     * Handles a push message received from the platform (e.g. FCM on Android).
-     * This function should parse the payload and show a local notification,
-     * or trigger custom logic depending on the app’s needs.
+     * Handles a push message received from the platform.
+     * This function parses the payload and shows a local notification.
      *
      * @param data The key-value payload of the remote push message.
      */
     fun onMessageReceived(data: Map<String, String>)
 
+    /**
+     * Retrieves the current Firebase Cloud Messaging (FCM) token for the device.
+     * This token uniquely identifies the app instance and is required for sending push notifications.
+     *
+     * On iOS, this method waits for the APNs token to be set before fetching the FCM token.
+     *
+     * @return A [Result] containing the FCM token on success, or an exception on failure.
+     */
+    suspend fun getToken(): Result<String>
 }

--- a/alarmee/src/nonMobileMain/kotlin/com/tweener/alarmee/DefaultAlarmeeService.nonMobile.kt
+++ b/alarmee/src/nonMobileMain/kotlin/com/tweener/alarmee/DefaultAlarmeeService.nonMobile.kt
@@ -12,10 +12,12 @@ actual fun initializeFirebase() {
     // No-op for non-mobile platforms
 }
 
-actual fun createAlarmeeService(config: AlarmeePlatformConfiguration): AlarmeeService =
-    DefaultAlarmeeService().apply {
-        onAppLaunch(platformConfiguration = config)
-    }
+actual fun configureFirebase() {
+    // No-op for non-mobile platforms
+}
+
+actual fun createAlarmeeService(): AlarmeeService =
+    DefaultAlarmeeService()
 
 actual fun createLocalNotificationService(config: AlarmeePlatformConfiguration): LocalNotificationService {
     requirePlatformConfiguration(providedPlatformConfiguration = config, targetPlatformConfiguration = AlarmeePlatformConfigurationNonMobile::class)

--- a/buildSrc/src/main/kotlin/ProjectConfiguration.kt
+++ b/buildSrc/src/main/kotlin/ProjectConfiguration.kt
@@ -9,7 +9,7 @@ object ProjectConfiguration {
 
     object Alarmee {
         const val packageName = "com.tweener.alarmee"
-        const val versionName = "2.0.0"
+        const val versionName = "2.0.1"
         const val namespace = "$packageName.android"
         const val compileSDK = 35
         const val minSDK = 24


### PR DESCRIPTION
- Allow Alarmee to be initialized by passing a Firebase instance
- Exposes the FCM token via `PushNotificationService#getToken()`