### PR TITLE
Use deep link URI hashCode as requestCode in PendingIntent creation - Fixes #24

### DIFF
--- a/alarmee/src/androidMain/kotlin/com/tweener/alarmee/notification/NotificationFactory.kt
+++ b/alarmee/src/androidMain/kotlin/com/tweener/alarmee/notification/NotificationFactory.kt
@@ -69,7 +69,7 @@ class NotificationFactory {
                 addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
                 deepLinkUri?.let { putExtra(DEEP_LINK_URI_PARAM, it) } // Pass the deep link URI to the activity
             }
-            return PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
+            return PendingIntent.getActivity(context, deepLinkUri?.hashCode() ?: 0, intent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
         }
 
         private fun Context.getLauncherActivityIntent(): Intent? = applicationContext.packageManager.getLaunchIntentForPackage(applicationContext.packageName)


### PR DESCRIPTION
Use the `deepLinkUri`'s `hashCode` as the `PendingIntent`'s request code. This ensures that whenever a `deepLinkUri` is present, then the `PendingIntent` is unique to that deeplink, so it doesn't overwrite other notification's intents, and if no deeplink if provided, then it will only be opening the app as usual anyway so it's ok to use `0` as the request code.

This fixes https://github.com/Tweener/alarmee/issues/24