### PR TITLE
Fix: respect useExactScheduling for repeating alarms on Android

### DIFF
--- a/alarmee/src/androidMain/kotlin/com/tweener/alarmee/DefaultLocalNotificationService.android.kt
+++ b/alarmee/src/androidMain/kotlin/com/tweener/alarmee/DefaultLocalNotificationService.android.kt
@@ -84,7 +84,8 @@ actual fun scheduleRepeatingAlarm(alarmee: Alarmee, repeatInterval: RepeatInterv
         if (config.useExactScheduling && canScheduleExactAlarms(alarmManager)) {
             // Use exact one-shot alarm with chaining for precise timing.
             // The receiver will reschedule the next occurrence after showing the notification.
-            val pendingIntent = getPendingIntent(alarmee = alarmee, config = config, repeatIntervalMillis = intervalMillis)
+            // nextTriggerMillis anchors the chain to the original schedule grid to avoid drift.
+            val pendingIntent = getPendingIntent(alarmee = alarmee, config = config, repeatIntervalMillis = intervalMillis, nextTriggerMillis = triggerAtMillis + intervalMillis)
             alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAtMillis, pendingIntent)
         } else {
             val pendingIntent = getPendingIntent(alarmee = alarmee, config = config)
@@ -219,7 +220,7 @@ private fun validateNotificationChannelId(alarmee: Alarmee) {
     }
 }
 
-private fun getPendingIntent(alarmee: Alarmee, config: AlarmeePlatformConfiguration, repeatIntervalMillis: Long? = null): PendingIntent {
+private fun getPendingIntent(alarmee: Alarmee, config: AlarmeePlatformConfiguration, repeatIntervalMillis: Long? = null, nextTriggerMillis: Long? = null): PendingIntent {
     requirePlatformConfiguration(providedPlatformConfiguration = config, targetPlatformConfiguration = AlarmeeAndroidPlatformConfiguration::class)
 
     val priority = mapPriority(priority = alarmee.androidNotificationConfiguration.priority)
@@ -251,6 +252,12 @@ private fun getPendingIntent(alarmee: Alarmee, config: AlarmeePlatformConfigurat
         // For exact repeating: pass interval so receiver can chain the next alarm
         if (repeatIntervalMillis != null) {
             putExtra(NotificationBroadcastReceiver.KEY_REPEAT_INTERVAL_MILLIS, repeatIntervalMillis)
+        }
+
+        // For exact repeating: pass the intended trigger time of the next occurrence so the
+        // receiver can anchor the chain to the original schedule grid instead of drifting.
+        if (nextTriggerMillis != null) {
+            putExtra(NotificationBroadcastReceiver.KEY_NEXT_TRIGGER_MILLIS, nextTriggerMillis)
         }
     }
 

--- a/alarmee/src/androidMain/kotlin/com/tweener/alarmee/DefaultLocalNotificationService.android.kt
+++ b/alarmee/src/androidMain/kotlin/com/tweener/alarmee/DefaultLocalNotificationService.android.kt
@@ -68,8 +68,6 @@ actual fun scheduleRepeatingAlarm(alarmee: Alarmee, repeatInterval: RepeatInterv
     requirePlatformConfiguration(providedPlatformConfiguration = config, targetPlatformConfiguration = AlarmeeAndroidPlatformConfiguration::class)
     validateNotificationChannelId(alarmee = alarmee)
 
-    val pendingIntent = getPendingIntent(alarmee = alarmee, config = config)
-
     // Schedule the alarm according to the repeat interval
     val intervalMillis = when (repeatInterval) {
         is RepeatInterval.Hourly -> AlarmManager.INTERVAL_HOUR
@@ -82,7 +80,16 @@ actual fun scheduleRepeatingAlarm(alarmee: Alarmee, repeatInterval: RepeatInterv
 
     applicationContext.getAlarmManager()?.let { alarmManager ->
         val triggerAtMillis = (alarmee.scheduledDateTime ?: LocalDateTime.now(timeZone = alarmee.timeZone)).toEpochMilliseconds(timeZone = alarmee.timeZone)
-        alarmManager.setRepeating(AlarmManager.RTC_WAKEUP, triggerAtMillis, intervalMillis, pendingIntent)
+
+        if (config.useExactScheduling && canScheduleExactAlarms(alarmManager)) {
+            // Use exact one-shot alarm with chaining for precise timing.
+            // The receiver will reschedule the next occurrence after showing the notification.
+            val pendingIntent = getPendingIntent(alarmee = alarmee, config = config, repeatIntervalMillis = intervalMillis)
+            alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAtMillis, pendingIntent)
+        } else {
+            val pendingIntent = getPendingIntent(alarmee = alarmee, config = config)
+            alarmManager.setRepeating(AlarmManager.RTC_WAKEUP, triggerAtMillis, intervalMillis, pendingIntent)
+        }
 
         // Notification scheduled successfully
         onSuccess()
@@ -212,7 +219,7 @@ private fun validateNotificationChannelId(alarmee: Alarmee) {
     }
 }
 
-private fun getPendingIntent(alarmee: Alarmee, config: AlarmeePlatformConfiguration): PendingIntent {
+private fun getPendingIntent(alarmee: Alarmee, config: AlarmeePlatformConfiguration, repeatIntervalMillis: Long? = null): PendingIntent {
     requirePlatformConfiguration(providedPlatformConfiguration = config, targetPlatformConfiguration = AlarmeeAndroidPlatformConfiguration::class)
 
     val priority = mapPriority(priority = alarmee.androidNotificationConfiguration.priority)
@@ -239,6 +246,11 @@ private fun getPendingIntent(alarmee: Alarmee, config: AlarmeePlatformConfigurat
         // Serialize actions to JSON
         if (alarmee.actions.isNotEmpty()) {
             putExtra(NotificationBroadcastReceiver.KEY_ACTIONS_JSON, serializeActions(alarmee.actions))
+        }
+
+        // For exact repeating: pass interval so receiver can chain the next alarm
+        if (repeatIntervalMillis != null) {
+            putExtra(NotificationBroadcastReceiver.KEY_REPEAT_INTERVAL_MILLIS, repeatIntervalMillis)
         }
     }
 

--- a/alarmee/src/androidMain/kotlin/com/tweener/alarmee/reveicer/NotificationBroadcastReceiver.kt
+++ b/alarmee/src/androidMain/kotlin/com/tweener/alarmee/reveicer/NotificationBroadcastReceiver.kt
@@ -1,8 +1,11 @@
 package com.tweener.alarmee.reveicer
 
+import android.app.AlarmManager
+import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.core.app.NotificationCompat
@@ -36,6 +39,7 @@ class NotificationBroadcastReceiver : BroadcastReceiver() {
         const val KEY_DEEP_LINK_URI = "notificationDeepLinkUri"
         const val KEY_IMAGE_URL = "notificationImageUrl"
         const val KEY_ACTIONS_JSON = "notificationActionsJson"
+        const val KEY_REPEAT_INTERVAL_MILLIS = "notificationRepeatIntervalMillis"
 
         val DEFAULT_ICON_RES_ID = R.drawable.ic_notification
         val DEFAULT_ICON_COLOR = Color.Transparent
@@ -52,6 +56,13 @@ class NotificationBroadcastReceiver : BroadcastReceiver() {
                 intent.getStringExtra(KEY_TITLE),
                 intent.getStringExtra(KEY_BODY),
             ) { uuid, title, body ->
+                // Chain the next exact alarm before showing the notification,
+                // so the chain continues even if notification display fails.
+                val repeatIntervalMillis = intent.getLongExtra(KEY_REPEAT_INTERVAL_MILLIS, -1L)
+                if (repeatIntervalMillis > 0) {
+                    scheduleNextExactAlarm(context, intent, uuid, repeatIntervalMillis)
+                }
+
                 val priority = intent.getIntExtra(KEY_PRIORITY, DEFAULT_PRIORITY)
                 val iconResId = intent.getIntExtra(KEY_ICON_RES_ID, DEFAULT_ICON_RES_ID)
                 val iconColor = intent.getIntExtra(KEY_ICON_COLOR, DEFAULT_ICON_COLOR.toArgb())
@@ -93,6 +104,36 @@ class NotificationBroadcastReceiver : BroadcastReceiver() {
                     }
                 }
             }
+        }
+    }
+
+    /**
+     * Schedules the next exact alarm for repeating notifications.
+     * Uses one-shot exact chaining: after each alarm fires, the next one is scheduled.
+     * Falls back to inexact scheduling if the SCHEDULE_EXACT_ALARM permission was revoked.
+     */
+    private fun scheduleNextExactAlarm(context: Context, originalIntent: Intent, uuid: String, intervalMillis: Long) {
+        val nextTriggerMillis = System.currentTimeMillis() + intervalMillis
+
+        // Clone the intent preserving all extras (notification data + repeat interval)
+        val nextIntent = Intent(originalIntent).apply {
+            setClass(context, NotificationBroadcastReceiver::class.java)
+        }
+
+        val pendingIntent = PendingIntent.getBroadcast(
+            context,
+            uuid.hashCode(),
+            nextIntent,
+            PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as? AlarmManager ?: return
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S || alarmManager.canScheduleExactAlarms()) {
+            alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, nextTriggerMillis, pendingIntent)
+        } else {
+            // Permission was revoked — fall back to inexact
+            alarmManager.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, nextTriggerMillis, pendingIntent)
         }
     }
 

--- a/alarmee/src/androidMain/kotlin/com/tweener/alarmee/reveicer/NotificationBroadcastReceiver.kt
+++ b/alarmee/src/androidMain/kotlin/com/tweener/alarmee/reveicer/NotificationBroadcastReceiver.kt
@@ -40,6 +40,7 @@ class NotificationBroadcastReceiver : BroadcastReceiver() {
         const val KEY_IMAGE_URL = "notificationImageUrl"
         const val KEY_ACTIONS_JSON = "notificationActionsJson"
         const val KEY_REPEAT_INTERVAL_MILLIS = "notificationRepeatIntervalMillis"
+        const val KEY_NEXT_TRIGGER_MILLIS = "notificationNextTriggerMillis"
 
         val DEFAULT_ICON_RES_ID = R.drawable.ic_notification
         val DEFAULT_ICON_COLOR = Color.Transparent
@@ -113,11 +114,27 @@ class NotificationBroadcastReceiver : BroadcastReceiver() {
      * Falls back to inexact scheduling if the SCHEDULE_EXACT_ALARM permission was revoked.
      */
     private fun scheduleNextExactAlarm(context: Context, originalIntent: Intent, uuid: String, intervalMillis: Long) {
-        val nextTriggerMillis = System.currentTimeMillis() + intervalMillis
+        val now = System.currentTimeMillis()
 
-        // Clone the intent preserving all extras (notification data + repeat interval)
+        // Anchor the next trigger to the original schedule grid to avoid drift. Each alarm fires
+        // slightly late (Doze wakeup latency, processing, exact-alarm throttling); computing the
+        // next trigger from the actual receive time would let that error accumulate over time.
+        // Fall back to now-based scheduling if the anchor is missing (e.g. an older chained intent).
+        val anchoredNext = originalIntent.getLongExtra(KEY_NEXT_TRIGGER_MILLIS, -1L)
+        var nextTriggerMillis = if (anchoredNext > 0) anchoredNext else now + intervalMillis
+
+        // Catch up: if one or more occurrences were missed (device asleep/off, long Doze), skip
+        // forward to the next future slot on the grid instead of firing a burst of past alarms.
+        if (nextTriggerMillis <= now) {
+            val missedIntervals = (now - nextTriggerMillis) / intervalMillis + 1
+            nextTriggerMillis += missedIntervals * intervalMillis
+        }
+
+        // Clone the intent preserving all extras (notification data + repeat interval), updating
+        // the anchor to the occurrence that follows the one we're scheduling now.
         val nextIntent = Intent(originalIntent).apply {
             setClass(context, NotificationBroadcastReceiver::class.java)
+            putExtra(KEY_NEXT_TRIGGER_MILLIS, nextTriggerMillis + intervalMillis)
         }
 
         val pendingIntent = PendingIntent.getBroadcast(


### PR DESCRIPTION
scheduleRepeatingAlarm() previously always used AlarmManager.setRepeating(), which is inexact on API 19+ (equivalent to setInexactRepeating). This ignored the useExactScheduling flag, causing repeating alarms to fire with significant delays (up to 40+ minutes due to Doze mode batching).

When useExactScheduling is true and the app has SCHEDULE_EXACT_ALARM permission, repeating alarms now use one-shot exact chaining: the first occurrence is scheduled with setExactAndAllowWhileIdle(), and the BroadcastReceiver chains the next occurrence after each alarm fires.

If the permission is revoked between firings, it gracefully falls back to setAndAllowWhileIdle().